### PR TITLE
Bugfix/fix serializer

### DIFF
--- a/pymantic/primitives.py
+++ b/pymantic/primitives.py
@@ -711,13 +711,44 @@ u"http://www.w3.org/2000/01/rdf-schema#label"
         return iri
 
 
+class Base(dict):
+    """A map that stores bases and provides helper methods to transform IRIs
+    with bases.
+
+Example usage:
+
+>>> base = Base()
+
+Add a mapping for the base:
+
+>>> base['base'] = 'https://example.com/foo#'
+
+Shrink an IRI with base to only the non-base elements
+
+>>> base.shrink('https://example.com/foo#bar')
+u"#bar"
+
+    """
+
+    def shrink(self, iri):
+        """Given an IRI with a particular base -- for example IRI
+        'https://example.com/foo#bar' and base 'https://example.com/foo#' --
+        this method returns '#bar'. If no base is known the original IRI is
+        returned."""
+        for term, v in iteritems(self):
+            if v in iri:
+                return iri.replace(v, "#")
+        return iri
+
+
 class Profile(object):
     """Profiles provide an easy to use context for negotiating between CURIEs,
     Terms and IRIs."""
 
-    def __init__(self, prefixes=None, terms=None):
+    def __init__(self, prefixes=None, terms=None, base=None):
         self.prefixes = prefixes or PrefixMap()
         self.terms = terms or TermMap()
+        self.base = base or Base()
         if 'rdf' not in self.prefixes:
             self.prefixes['rdf'] = \
                 'http://www.w3.org/1999/02/22-rdf-syntax-ns#'

--- a/pymantic/primitives.py
+++ b/pymantic/primitives.py
@@ -413,29 +413,35 @@ class Graph(object):
                     if Triple(subject, predicate, object) in self:
                         yield Triple(subject, predicate, object)
                 else:  # s, p, ?var
-                    for triple in itervalues(self._spo[subject][predicate]):
-                        yield triple
+                    if subject in self._spo and predicate in self._spo[subject]:
+                        for triple in itervalues(self._spo[subject][predicate]):
+                            yield triple
             else:  # s, ?var, ???
                 if object:  # s, ?var, o
-                    for triple in itervalues(self._osp[object][subject]):
-                        yield triple
-                else:  # s, ?var, ?var
-                    for predicate in self._spo[subject]:
-                        for triple in \
-                          itervalues(self._spo[subject][predicate]):
+                    if object in self._osp and subject in self._osp[object]:
+                        for triple in itervalues(self._osp[object][subject]):
                             yield triple
+                else:  # s, ?var, ?var
+                    if subject in self._spo:
+                        for predicate in self._spo[subject]:
+                            for triple in \
+                              itervalues(self._spo[subject][predicate]):
+                                yield triple
         elif predicate:  # ?var, p, ???
             if object:  # ?var, p, o
-                for triple in itervalues(self._pos[predicate][object]):
-                    yield triple
-            else:  # ?var, p, ?var
-                for object in self._pos[predicate]:
+                if predicate in self._pos and object in self._pos[predicate]:
                     for triple in itervalues(self._pos[predicate][object]):
                         yield triple
+            else:  # ?var, p, ?var
+                if predicate in self._pos:
+                    for object in self._pos[predicate]:
+                        for triple in itervalues(self._pos[predicate][object]):
+                            yield triple
         elif object:  # ?var, ?var, o
-            for subject in self._osp[object]:
-                for triple in itervalues(self._osp[object][subject]):
-                    yield triple
+            if object in self._osp:
+                for subject in self._osp[object]:
+                    for triple in itervalues(self._osp[object][subject]):
+                        yield triple
         else:
             for triple in self._triples:
                 yield triple

--- a/pymantic/primitives.py
+++ b/pymantic/primitives.py
@@ -618,12 +618,13 @@ class PrefixMap(collections.OrderedDict):
         "http://www.w3.org/2000/01/rdf-schema#label") this method returns a
         CURIE (for example "rdfs:label"). If no prefix is known the original
         IRI is returned. If a base is provided and IRI starts with that base,
-        the base is stripped out and replaced with '#'."""
+        the base is stripped out; an initial `#` is added if needed."""
         curie = to_curie(iri, self)
         if base and curie.startswith(base):
-            return curie.replace(base, "#")
-        else:
-            return curie
+            if base.endswith("#"):
+                return curie.replace(base, "#")
+            return curie.replace(base, "")
+        return curie
 
     def addAll(self, other, override=False):
         if override:

--- a/pymantic/serializers.py
+++ b/pymantic/serializers.py
@@ -64,14 +64,11 @@ def turtle_string_escape(string):
 def turtle_repr(node, profile, name_map, bnode_name_maker, base=None):
     """Turn a node in an RDF graph into its turtle representation."""
     if node.interfaceName == 'NamedNode':
-        name = profile.prefixes.shrink(node)
-        if name == node:
-            name = '<' + text_type(node) + '>'
+        name = profile.prefixes.shrink(node, base)
+        if name == node or (base and name.startswith("#")):
+            name = '<' + text_type(name) + '>'
         else:
             escape_prefix_local(name)
-        if base:
-            profile.base['base'] = base
-            name = profile.base.shrink(name)
     elif node.interfaceName == 'BlankNode':
         if node in name_map:
             name = name_map[node]

--- a/pymantic/serializers.py
+++ b/pymantic/serializers.py
@@ -65,7 +65,7 @@ def turtle_repr(node, profile, name_map, bnode_name_maker, base=None):
     """Turn a node in an RDF graph into its turtle representation."""
     if node.interfaceName == 'NamedNode':
         name = profile.prefixes.shrink(node, base)
-        if name == node or (base and name.startswith("#")):
+        if name == node or (base and node.startswith(base)):
             name = '<' + text_type(name) + '>'
         else:
             escape_prefix_local(name)

--- a/pymantic/serializers.py
+++ b/pymantic/serializers.py
@@ -69,6 +69,9 @@ def turtle_repr(node, profile, name_map, bnode_name_maker, base=None):
             name = '<' + text_type(node) + '>'
         else:
             escape_prefix_local(name)
+        if base:
+            profile.base['base'] = base
+            name = profile.base.shrink(name)
     elif node.interfaceName == 'BlankNode':
         if node in name_map:
             name = name_map[node]
@@ -96,8 +99,6 @@ def turtle_repr(node, profile, name_map, bnode_name_maker, base=None):
             # Unrecognized data-type.
             name = turtle_string_escape(node.value)
             name += '^' + turtle_repr(node.datatype, profile, None, None)
-    if base and base in name:
-        name = name.replace(base, "#")
     return name
 
 def turtle_sorted_names(l, name_maker):

--- a/pymantic/serializers.py
+++ b/pymantic/serializers.py
@@ -61,7 +61,7 @@ def turtle_string_escape(string):
         string = string.replace(value, '\\' + escaped)
     return '"' + string + '"'
 
-def turtle_repr(node, profile, name_map, bnode_name_maker):
+def turtle_repr(node, profile, name_map, bnode_name_maker, base=None):
     """Turn a node in an RDF graph into its turtle representation."""
     if node.interfaceName == 'NamedNode':
         name = profile.prefixes.shrink(node)
@@ -96,6 +96,8 @@ def turtle_repr(node, profile, name_map, bnode_name_maker):
             # Unrecognized data-type.
             name = turtle_string_escape(node.value)
             name += '^' + turtle_repr(node.datatype, profile, None, None)
+    if base and base in name:
+        name = name.replace(base, "#")
     return name
 
 def turtle_sorted_names(l, name_maker):
@@ -121,7 +123,7 @@ def serialize_turtle(graph, f, base=None, profile=None,
     output_order = []
     bnode_name_maker = bnode_name_generator()
 
-    name_maker = lambda n: turtle_repr(n, profile, name_map, bnode_name_maker)
+    name_maker = lambda n: turtle_repr(n, profile, name_map, bnode_name_maker, base)
 
     from pymantic.rdf import List
 

--- a/pymantic/tests/test_serializers.py
+++ b/pymantic/tests/test_serializers.py
@@ -85,6 +85,13 @@ class TestTurtleRepresentation(TestCase):
         name = self.turtle_repr(node = node, profile = self.profile, name_map = None, bnode_name_maker = None)
         self.assertEqual(name, 'ex:foo')
 
+    def test_named_node_with_base(self):
+        node = self.primitives.NamedNode('https://example.com/foo#bar')
+        name = self.turtle_repr(node = node, profile = self.profile, name_map = None, bnode_name_maker = None,
+                                base='https://example.com/foo#')
+        self.assertEqual(name, '<#bar>')
+
+
 class TestTurtleSerializer(TestCase):
     def setUp(self):
         from pymantic.parsers import turtle_parser


### PR DESCRIPTION
- Fixed bug accidentally writing values to `self._spo`, `._pos`, and `._osp` during calls to `graph.match`
- Added optional `base` arg to `turtle_repr` and used it to ensure that serialized output respects a given base. I'm not sure that adding the new `Base` class with its own `shrink` makes the most sense here. For one thing, we shouldn't have multiple bases that will really require storage in a dict. Maybe adapting `Terms.shrink`  to handle this correctly would be better?
- Added a test for `turtle_repr` exercising the new arg when repring a `NamedNode`.