### PR TITLE
Separate base handling from prefix.shrink and handle directly in turt…

### DIFF
--- a/pymantic/primitives.py
+++ b/pymantic/primitives.py
@@ -613,18 +613,12 @@ class PrefixMap(collections.OrderedDict):
         "http://www.w3.org/2000/01/rdf-schema#label")"""
         return parse_curie(curie, self)
 
-    def shrink(self, iri, base=None):
+    def shrink(self, iri):
         """Given an IRI for which a prefix is known (for example
         "http://www.w3.org/2000/01/rdf-schema#label") this method returns a
-        CURIE (for example "rdfs:label"). If no prefix is known the original
-        IRI is returned. If a base is provided and IRI starts with that base,
-        the base is stripped out; an initial `#` is added if needed."""
-        curie = to_curie(iri, self)
-        if base and curie.startswith(base):
-            if base.endswith("#"):
-                return curie.replace(base, "#")
-            return curie.replace(base, "")
-        return curie
+        CURIE (for example "rdfs:label"), if no prefix is known the original
+        IRI is returned."""
+        return to_curie(iri, self)
 
     def addAll(self, other, override=False):
         if override:

--- a/pymantic/serializers.py
+++ b/pymantic/serializers.py
@@ -64,8 +64,13 @@ def turtle_string_escape(string):
 def turtle_repr(node, profile, name_map, bnode_name_maker, base=None):
     """Turn a node in an RDF graph into its turtle representation."""
     if node.interfaceName == 'NamedNode':
-        name = profile.prefixes.shrink(node, base)
-        if name == node or (base and node.startswith(base)):
+        name = profile.prefixes.shrink(node)
+        if base and name.startswith(base):
+            if base.endswith("#"):
+                name = '<' + text_type(name.replace(base, "#")) + '>'
+            else:
+                name = '<' + text_type(name.replace(base, "")) + '>'
+        if name == node:
             name = '<' + text_type(name) + '>'
         else:
             escape_prefix_local(name)


### PR DESCRIPTION
…le_repr

- Remove base handling fro profile.shrink. This function should match its previous iteration.
- Add base handling to turtle_repr instead.
- This should allow for correct handling of both base and prefixes.
- All tests on branch should now pass.