### PR TITLE
Adding options parameter to pass on to to_rdf()

### DIFF
--- a/pymantic/parsers/jsonld.py
+++ b/pymantic/parsers/jsonld.py
@@ -24,11 +24,11 @@ class PyLDLoader(BaseParser):
             jobj = json.loads(string)
             self.pyld_loader.process_jobj(jobj)
 
-    def parse_json(self, jobj, sink=None):
+    def parse_json(self, jobj, sink=None, options=None):
         if sink is None:
             sink = self._make_graph()
         self._prepare_parse(sink)
-        self.process_jobj(jobj)
+        self.process_jobj(jobj, options)
         self._cleanup_parse()
 
         return sink

--- a/pymantic/parsers/jsonld.py
+++ b/pymantic/parsers/jsonld.py
@@ -60,9 +60,9 @@ class PyLDLoader(BaseParser):
                 language=language
             )
 
-    def process_jobj(self, jobj):
+    def process_jobj(self, jobj, options=None):
         from pyld.jsonld import to_rdf
-        dataset = to_rdf(jobj)
+        dataset = to_rdf(jobj, options=options)
         for graph_name, triples in dataset.items():
             graph_iri = (
                 self.env.createNamedNode(graph_name) if

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name='pymantic',
           'lxml',
           'pytz',
           'rdflib',
-          'lark-parser>=0.7.0',
+          'lark-parser>=0.7.0,<0.7.2',
           'pyld',
           ],
       extras_require={


### PR DESCRIPTION
We need to be able to set the base when calling `process_jobj()`, so this adds the ability to pass in options for `to_rdf()`